### PR TITLE
Add vasprun parsing for split k-point paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ effmass.egg-info/
 __pycache__/
 docs/build/
 **/.pytest_cache
+**/.vscode/*


### PR DESCRIPTION
Added a DataVasprun class in inputs to parse data directly from a vasprun.xml file. It can parse individual vaspruns or vaspruns from split k-point paths i.e. as generated with sumo for hybrid calculations like shown below:

```
band/              
  ├── split-01/    
  ├── split-02/
  ├── split-03/
  └── split-04/
    └── vasprun.xml
```

DataVasprun only needs one argument - `path` to files. If we are interested in parsing only one specific vasprun that contains the entire k-point path, `path=path/to/vasprun.xml`. However, in the case of multiple folders with separate vaspruns, such as above, `path=band` will parse all the subfolders and vaspruns from there. Specifically this is made to work with sumo formatting but it should be easy enough to adapt to any other formats. 